### PR TITLE
Add KSP_VERSION_MAX

### DIFF
--- a/JanitorsCloset.version
+++ b/JanitorsCloset.version
@@ -19,7 +19,7 @@
     "MAJOR": 1,
     "MINOR": 4,
     "PATCH": 1
-  }
+  },
   "KSP_VERSION_MAX": 
   {
     "MAJOR": 1,

--- a/JanitorsCloset.version
+++ b/JanitorsCloset.version
@@ -20,4 +20,10 @@
     "MINOR": 4,
     "PATCH": 1
   }
+  "KSP_VERSION_MAX": 
+  {
+    "MAJOR": 1,
+    "MINOR": 4,
+    "PATCH": 99
+  }
 }


### PR DESCRIPTION
I don't know if 1.4.99 is entirely appropriate here. I _do_ know that it appears to work fine in 1.4.3, so I'm extrapolating out to all patch versions. :simple_smile: