### PR TITLE
Always use forward slashes for CKAN filters

### DIFF
--- a/JanitorsCloset/PermaPrune.cs
+++ b/JanitorsCloset/PermaPrune.cs
@@ -521,8 +521,8 @@ namespace JanitorsCloset
                 : Enumerable.Empty<string>();
 
         private static string OriginalGameDataRelativePath(prunedPart pp)
-            => Path.Combine("GameData", pp.path.Replace("\\", "/")
-                                               .Replace(PRUNED, ""));
+            => "GameData/" + pp.path.Replace("\\", "/")
+                                    .Replace(PRUNED, "");
 
         void unpruner()
         {


### PR DESCRIPTION
Hey @linuxgurugamer, sorry about that, I meant to change this but forgot to commit it.
CKAN will always use `/` as the path separator for filters, so it's important for the strings generated by this code to match.
