### PR TITLE
Fix Alt+RightClick hide menu when no buttons are customized yet

### DIFF
--- a/JanitorsCloset/ToolbarIconEvents.cs
+++ b/JanitorsCloset/ToolbarIconEvents.cs
@@ -148,19 +148,15 @@ namespace JanitorsCloset
                     return;
 
                 RefreshAppLists();
-
-                if (HasToolbarCustomizationData())
-                    InstallMissingHandlers();
-
+                // Always install click handlers so Alt+RightClick hide menu works
+                // even when no buttons have been hidden/folded yet.
+                InstallMissingHandlers();
                 RequestToolbarSync();
             }
 
             private void RequestToolbarSync()
             {
                 if (!ShouldRunToolbarSyncInCurrentScene())
-                    return;
-
-                if (!HasToolbarCustomizationData())
                     return;
 
                 if (syncCoroutine != null)
@@ -179,18 +175,15 @@ namespace JanitorsCloset
                         yield break;
 
                     RefreshAppLists();
+                    // Keep installing handlers for late-appearing toolbar buttons.
+                    InstallMissingHandlers();
 
-                    if (HasToolbarCustomizationData())
-                        InstallMissingHandlers();
-
-                    if (!HasPendingToolbarWork())
-                        yield break;
-
-                    UpdateButtonDictionary();
-                    CheckToolbarButtons();
-
-                    if (!HasPendingToolbarWork())
-                        yield break;
+                    // Heavy hide/folder sync only when there is saved customization work.
+                    if (HasToolbarCustomizationData() && HasPendingToolbarWork())
+                    {
+                        UpdateButtonDictionary();
+                        CheckToolbarButtons();
+                    }
 
                     yield return new WaitForSeconds(SyncIntervalSeconds);
                     elapsed += SyncIntervalSeconds;


### PR DESCRIPTION
Always install toolbar click handlers after scene changes; keep heavy hide/folder sync gated behind existing customization data.