### PR TITLE
Make the UI automatically adjust to KSP's UI Scale

### DIFF
--- a/JanitorsCloset/Settings.cs
+++ b/JanitorsCloset/Settings.cs
@@ -42,6 +42,14 @@ namespace JanitorsCloset
                    toolTip = "Time popup menu/toolbar stays around after mouse is moved away")]
         public float hoverTimeout = 0.5f;
 
+        [GameParameters.CustomParameterUI("Auto UI scale by resolution",
+            toolTip = "When enabled, UI scale follows screen height: 75% at 4K, 85% at 1440p, 100% at 1080p. Disable to use the slider below manually.")]
+        public bool uiScaleAuto = true;
+
+        [GameParameters.CustomFloatParameterUI("UI scale (%)", minValue = 50f, maxValue = 150f, stepCount = 100, displayFormat = "N0",
+                   toolTip = "Extra multiplier for JC windows on top of KSP UI scale. 100 matches KSP; 50 is half size; 150 is 1.5x. Read-only while auto mode is enabled.")]
+        public float uiScalePercent = 100f;
+
         [GameParameters.CustomParameterUI("Enable hover on icons in the JC toolbar")]
         public bool enabeHoverOnToolbarIcons = true;
 
@@ -62,19 +70,29 @@ namespace JanitorsCloset
         [GameParameters.CustomParameterUI("Debug mode (spams the log file")]
         public bool debug = false;
 
+        public void ApplyAutoUiScale()
+        {
+            if (!uiScaleAuto)
+                return;
+            uiScalePercent = UIScale.DefaultUiScalePercent;
+        }
+
         public override bool Enabled(MemberInfo member, GameParameters parameters)
         {
+            if (uiScaleAuto)
+                ApplyAutoUiScale();
+
             if (member.Name == "toolbarPopupsEnabled" || member.Name == "toolbarEditorOnly")
                 return toolbarEnabled;
 
-            return true; //otherwise return true
+            return true;
         }
 
         public override bool Interactible(MemberInfo member, GameParameters parameters)
         {
-
+            if (member.Name == "uiScalePercent" && uiScaleAuto)
+                return false;
             return true;
-            //            return true; //otherwise return true
         }
 
         public override IList ValidValues(MemberInfo member)

--- a/JanitorsCloset/UIScale.cs
+++ b/JanitorsCloset/UIScale.cs
@@ -4,7 +4,7 @@ namespace JanitorsCloset
 {
     /// <summary>
     /// UI scaling for IMGUI mod windows.
-    /// Uses KSP's UI scale settings; when those are at default, compensates for resolutions above 1080p.
+    /// Final scale = KSP UI Scale × mod percent (50%–150%), matching OrbitalPayloadCalculator.
     /// </summary>
     public static class UIScale
     {
@@ -12,16 +12,45 @@ namespace JanitorsCloset
 
         public static bool IsActive { get; private set; }
 
+        public static float DefaultUiScalePercent
+        {
+            get
+            {
+                if (Screen.height >= 2160)
+                    return 75f;
+                if (Screen.height >= 1440)
+                    return 85f;
+                return 100f;
+            }
+        }
+
+        public static float ModUiScalePercent
+        {
+            get
+            {
+                if (HighLogic.CurrentGame == null)
+                    return DefaultUiScalePercent;
+                var settings = HighLogic.CurrentGame.Parameters.CustomParams<JanitorsClosetSettings>();
+                if (settings == null)
+                    return DefaultUiScalePercent;
+                if (settings.uiScaleAuto)
+                    return DefaultUiScalePercent;
+                return settings.uiScalePercent;
+            }
+        }
+
         public static float Factor
         {
             get
             {
-                var ksp = GameSettings.UI_SCALE * GameSettings.UI_SCALE_APPS;
-                if (ksp > 1.01f)
-                    return ksp;
-                if (Screen.height <= 1080)
-                    return ksp;
-                return Mathf.Max(ksp, (float)Screen.height / 1080f);
+                float ksp = GameSettings.UI_SCALE;
+                if (GameSettings.UI_SCALE_APPS > 1f)
+                    ksp *= GameSettings.UI_SCALE_APPS;
+                if (ksp <= 1.01f && Screen.height > 1080)
+                    ksp = Mathf.Max(ksp, Mathf.Min(1.5f, Mathf.Sqrt((float)Screen.height / 1080f)));
+
+                float mod = Mathf.Clamp(ModUiScalePercent / 100f, 0.5f, 1.5f);
+                return ksp * mod;
             }
         }
 


### PR DESCRIPTION
<img width="404" height="129" alt="0ea753c4-3cec-4076-9ce1-f81c4d1ef032" src="https://github.com/user-attachments/assets/b5a4e0de-ead2-4eb1-95f0-4aa5f76c428b" />

Add a UI adjustment slider to the difficulty settings to accommodate players' personal preferences and address the [issue](https://forum.kerbalspaceprogram.com/topic/147463-112x-end-your-parts-list-nightmare-introducing-the-janitors-closet/page/38/#findComment-4529823) raised by forum users.